### PR TITLE
minor tweak in case steam is undefined

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -9,7 +9,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const steam = getGamePath(1325260);
 
-if (!steam.game) {
+if (!steam?.game) {
     console.error('Kitsune Tails in Steam not found');
     process.exit(1);
 }


### PR DESCRIPTION
In initial testing, `steam` is undefined, so this line fails to error correctly.